### PR TITLE
add UUIDs to albums and songs

### DIFF
--- a/PitRadio.Api/Controllers/AlbumController.cs
+++ b/PitRadio.Api/Controllers/AlbumController.cs
@@ -30,5 +30,11 @@ namespace PitRadio.Api.Controllers
         {
             return _albumRepository.GetAlbumBySong(songname);
         }
+
+        [HttpGet(nameof(GetAlbumByUUID) + "/{uuid}")]
+        public Album GetAlbumBySong(string uuid)
+        {
+            return _albumRepository.GetAlbumByUUID(uuid);
+        }
     }
 }

--- a/PitRadio.Api/Data/Model/Album.cs
+++ b/PitRadio.Api/Data/Model/Album.cs
@@ -9,12 +9,14 @@ namespace PitRadio.Api.Data.Model
     {
         public Album(string title, ushort year, string artist, IEnumerable<Song> songs)
         {
+            UUID = Guid.NewGuid();
             Title = title;
             Year = year;
             Artist = artist;
             Songs = songs;
         }
 
+        public string UUID { get; }
         public string Title { get; }
         public ushort Year { get; }
         public string Artist { get; }

--- a/PitRadio.Api/Data/Model/Song.cs
+++ b/PitRadio.Api/Data/Model/Song.cs
@@ -9,10 +9,12 @@ namespace PitRadio.Api.Data.Model
     {
         public Song(string title, string file)
         {
+            UUID = Guid.NewGuid();
             Title = title;
             File = file;
         }
 
+        public string UUID { get; }
         public string Title { get; }
         public string File { get; }
     }

--- a/PitRadio.Api/Data/Repository/AlbumRepository.cs
+++ b/PitRadio.Api/Data/Repository/AlbumRepository.cs
@@ -27,5 +27,10 @@ namespace PitRadio.Api.Data.Repository
         {
             return _albums.FirstOrDefault(album => album.Songs.FirstOrDefault(song => song.Title == songname) != default(Song));
         }
+
+        public Album GetAlbumByUUID(string uuid)
+        {
+            return _albums.FirstOrDefault(album => album.Songs.FirstOrDefault(song => song.Title == uuid) != default(Song));
+        }
     }
 }


### PR DESCRIPTION
We need a system to individually refer to songs and albums which is not based on names and easy to handle.
I propose to generate UUIDs for all albums and songs and use them to refer to objects in communication between API and UI/App.